### PR TITLE
Add Default enum Literal to the xml parser

### DIFF
--- a/examples/dynsub/dyntypelib.c
+++ b/examples/dynsub/dyntypelib.c
@@ -577,8 +577,14 @@ static dds_return_t make_enum (const struct make_context *ctxt, const struct ele
     int pos;
     if (sscanf (valuestr, "%"SCNd32"%n", &value, &pos) != 1 || valuestr[pos] != 0)
       return dtl_set_error (err, m, "value not a plain integer %s\n", valuestr);
-
-    rc = dds_dynamic_type_add_enum_literal (denum, mname, DDS_DYNAMIC_ENUM_LITERAL_VALUE(value), false);
+    const char *defaultstr = getattr (m, "defaultLiteral");
+    bool is_default = false;
+    if (defaultstr != NULL && strcmp(defaultstr, "true") == 0)
+    {
+      is_default = true;
+    }
+    
+    rc = dds_dynamic_type_add_enum_literal (denum, mname, DDS_DYNAMIC_ENUM_LITERAL_VALUE(value), is_default);
     if (rc != DDS_RETCODE_OK)
       return dtl_set_error (err, m, "add_enum_literal failed: %s\n",  dds_strretcode (rc));
   }


### PR DESCRIPTION
Even if Cyclone doesn't fully support defaultLiteral for enums - the xml parser should still honor it