### PR TITLE
Update comment, enum literal should not be named "default"

### DIFF
--- a/examples/dynsub/dyntypelib.c
+++ b/examples/dynsub/dyntypelib.c
@@ -488,7 +488,7 @@ static dds_return_t make_union (const struct make_context *ctxt, const struct el
       const char *valstr = getattr (m, "value");
       if (valstr == NULL)
         return dtl_set_error (err, m, "no value in caseDiscriminator\n");
-      if (strcmp (valstr, "default") == 0) // what about an enum where "default" is a literal?
+      if (strcmp (valstr, "default") == 0)
         isdefault = true;
       else if (*valstr == 0)
         return dtl_set_error (err, m, "empty value in caseDiscriminator\n");


### PR DESCRIPTION
1. xtypes v1.3 specification, 7.3.2 XML Type Representation, Design rationale, the XML specification should be just a direct translation from the IDL specification, therefore the IDL specification should apply
2. IDL v4.2 specification, 7.4.2 Keywords, "default" is a default keyword, and any identifiers that collide with a keyword are illegal, e.g. boolean is a valid keyword, Boolean and BooLean would be illegal identifiers
3. IDL v4.2 specification, 7.4.1.4.4.4.3 Enumerations, enumerators are classified as identifiers

Therefore an enum with a literal named "default" would be an illegal enum and there would be a problem somewhere else in Cyclone for not catching it